### PR TITLE
Jira login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# *Storm IDEs
+.idea

--- a/server.js
+++ b/server.js
@@ -15,82 +15,74 @@
     app.use(methodOverride());
 
     // routes ======================================================================
-        // api ---------------------------------------------------------------------
+    // api ---------------------------------------------------------------------
 
-        // login to Jira
-        app.post('/api/login', function(req, res){
-            var Client = require('node-rest-client').Client;
-            client = new Client();
-            // Provide user credentials, which will be used to log in to JIRA.
-            var loginArgs = {
-                    data: {
-                            "username": req.body.username,
-                            "password": req.body.password
-                    },
+    // login to Jira
+    app.post('/api/login', function(req, res) {
+        var Client = require('node-rest-client').Client;
+        client = new Client();
+        // Provide user credentials, which will be used to log in to JIRA.
+        var loginArgs = {
+            data: {
+                    "username": req.body.username,
+                    "password": req.body.password
+            },
+            headers: {
+                    "Content-Type": "application/json"
+            }
+        };
+        client.post("https://xsolve.atlassian.net/rest/auth/latest/session", loginArgs, function(data, response){
+            if (response.statusCode == 200) {
+                console.log('succesfully logged in, session:', data.session);
+                console.log('original response header: ', response.headers['set-cookie']);
+                var cookies = [];
+                response.headers['set-cookie'].forEach(function(item, index) {
+                    cookies.push(item.split("; ")[0]);
+                });
+
+                cookies.splice(2, 1);
+
+                console.log('cookie header that we\'re actually passing to the request: ', cookies.join('; '));
+                var session = data.session;
+                // Get the session information and store it in a cookie in the header
+                var searchArgs = {
                     headers: {
+                            // Set the cookie from the session information
+                            "Cookie": cookies.join('; '),
                             "Content-Type": "application/json"
+                    },
+                    data: {
+                            //Provide additional data for the JIRA search. You can modify the JQL to search for whatever you want.
+                            "jql": "project=EZY",
+                            "startAt": 0,
+                            "maxResults": 15,
+                            "fields": [
+                                "summary",
+                                "status",
+                                "assignee"
+                            ],
+                            "fieldsByKeys": false
                     }
-            };
-            client.post("https://xsolve.atlassian.net/rest/auth/1/session", loginArgs, function(data, response){
-                    if (response.statusCode == 200) {
-                            console.log('succesfully logged in, session:', data.session);
-                            var session = data.session;
-                            // Get the session information and store it in a cookie in the header
-                            var searchArgs = {
-                                    headers: {
-            								// Set the cookie from the session information
-                                            cookie: session.name + '=' + session.value,
-                                            "Content-Type": "application/json"
-                                    },
-                                    data: {
-            								//Provide additional data for the JIRA search. You can modify the JQL to search for whatever you want.
-                                            "jql": "project=EZY",
-                                            "startAt": 0,
-                                            "maxResults": 15,
-                                            "fields": [
-                                                "summary",
-                                                "status",
-                                                "assignee"
-                                            ],
-                                            "fieldsByKeys": false
-                                    }
-                            };
-            				//Make the request return the search results, passing the header information including the cookie.
+                };
 
-                            //POST that doesn't work
-
-                            // client.post("https://xsolve.atlassian.net/rest/api/2/search", searchArgs, function(searchResult, response) {
-                            //         console.log('status code:', response.statusCode);
-                            //         console.log('search result:', searchResult);
-                            // });
-
-                            var getRequestArgs = {
-                                    headers: {
-            								// Set the cookie from the session information
-                                            cookie: session.name + '=' + session.value
-                                    }
-                            };
-                            console.log('cookie:', session.name + '=' + session.value);
-                            client.get("https://xsolve.atlassian.net/rest/auth/1/session", getRequestArgs, function(sessionData, response) {
-                                    console.log('status code:', response.statusCode);
-                                    console.log('our session details:', sessionData);
-                                    res.send('status code:' + response.statusCode)
-                            });
-                    }
-                    else {
-                        console.log("Login failed");
-                    }
-            });
-
-
+                client.get("https://xsolve.atlassian.net/rest/api/latest/myself", searchArgs, function(sessionData, response) {
+                    console.log('status code:', response.statusCode);
+                    console.log('our session details:', sessionData);
+                    res.send('status code:' + response.statusCode)
+                });
+            }
+            else {
+                console.log("Login failed");
+            }
         });
+    });
 
-        // application -------------------------------------------------------------
-        app.get('*', function() {
-            res.sendfile('.public/index.html'); // load the single view file (angular will handle the page changes on the front-end
-        });
+    // application -------------------------------------------------------------
+    app.get('*', function(req, res, next) {
+        res.sendFile('./public/index.html'); // load the single view file (angular will handle the page changes on the front-end
+    });
 
-        // listen (start app with node server.js) ======================================
-        var port = 4000;
-        app.listen(port);
-        console.log("App listening on port " + port);
+    // listen (start app with node server.js) ======================================
+    var port = 4000;
+    app.listen(port);
+    console.log("App listening on port " + port);


### PR DESCRIPTION
Ladies and gentlemen. Będę pisał po polsku bo późna godzina i w ogóle ;).

Tak w dużym skrócie. Aby zostać zautoryzowanym nie wystarczy przesłać cookie `JSESSIONID`. Dodatkowo należy jeszcze przesłać ciastka `studio.crowd.tokenkey` oraz `atlassian.xsrf.token`. Problem polega na tym, że w/w cookie nie są zwracane tak ładnie jak `JSESSIONID`, w obiekcie `session`, tylko w nagłówku `set-cookie`. To co zrobiłem to parsowanie oryginalnego nagłówka `set-cookie` do postaci, którą wysyłamy z naszym późniejszym requestem (np. szukając tasków).

Zmieniłem jeszcze parę rzeczy, m.in. "testowy" request na `GET /myself`. Teraz po zalogowaniu, w konsoli powinno zwrócić obiekt z danymi aktualnie zalogowanego użytkownika np:

```
{ self: 'https://xsolve.atlassian.net/rest/api/2/user?username=aleksandra.ostrowska',
  key: 'aleksandra.ostrowska',
  name: 'aleksandra.ostrowska',
  emailAddress: 'aleksandra.ostrowska@xsolve.pl',
  avatarUrls:
   { '16x16': 'https://xsolve.atlassian.net/secure/useravatar?size=xsmall&ownerId=aleksandra.ostrowska&avatarId=13302',
     '24x24': 'https://xsolve.atlassian.net/secure/useravatar?size=small&ownerId=aleksandra.ostrowska&avatarId=13302',
     '32x32': 'https://xsolve.atlassian.net/secure/useravatar?size=medium&ownerId=aleksandra.ostrowska&avatarId=13302',
     '48x48': 'https://xsolve.atlassian.net/secure/useravatar?ownerId=aleksandra.ostrowska&avatarId=13302' },
  displayName: 'Aleksandra Ostrowska',
  active: true,
  timeZone: 'Europe/Warsaw',
  locale: 'en_US',
  groups: { size: 7, items: [] },
  applicationRoles: { size: 1, items: [] },
  expand: 'groups,applicationRoles' }
```

Nie jestem jakimś wymiataczem w JS więc da się to pewnie zrobić ładniej/szybciej itp. Ale działa :)
